### PR TITLE
close old idle connections.

### DIFF
--- a/commons-httpclient/src/main/java/org/apache/commons/httpclient/HttpMethodDirector.java
+++ b/commons-httpclient/src/main/java/org/apache/commons/httpclient/HttpMethodDirector.java
@@ -73,6 +73,8 @@ class HttpMethodDirector {
 
     /** The proxy authenticate response header. */
     public static final String PROXY_AUTH_RESP = "Proxy-Authorization";
+    
+    private static final int DEFAULT_IDLE_TIMEOUT = 120000;
 
     private static final Log LOG = LogFactory.getLog(HttpMethodDirector.class);
 
@@ -150,7 +152,11 @@ class HttpMethodDirector {
         
                 // get a connection, if we need one
                 if (this.conn == null) {
-                    connectionManager.closeIdleConnections(60000);
+                    if (connectionManager.getParams().getSoTimeout()>0) {
+                        connectionManager.closeIdleConnections(connectionManager.getParams().getSoTimeout());
+                    } else {
+                        connectionManager.closeIdleConnections(DEFAULT_IDLE_TIMEOUT);
+                    }
                     this.conn = connectionManager.getConnectionWithTimeout(
                         hostConfiguration,
                         this.connectionManager.getParams().getConnectionTimeout()

--- a/commons-httpclient/src/main/java/org/apache/commons/httpclient/HttpMethodDirector.java
+++ b/commons-httpclient/src/main/java/org/apache/commons/httpclient/HttpMethodDirector.java
@@ -153,7 +153,7 @@ class HttpMethodDirector {
                     connectionManager.closeIdleConnections(60000);
                     this.conn = connectionManager.getConnectionWithTimeout(
                         hostConfiguration,
-                        this.params.getConnectionManagerTimeout() 
+                        this.connectionManager.getParams().getConnectionTimeout()
                     );
                     this.conn.setLocked(true);
                     if (this.params.isAuthenticationPreemptive()

--- a/commons-httpclient/src/main/java/org/apache/commons/httpclient/HttpMethodDirector.java
+++ b/commons-httpclient/src/main/java/org/apache/commons/httpclient/HttpMethodDirector.java
@@ -150,6 +150,7 @@ class HttpMethodDirector {
         
                 // get a connection, if we need one
                 if (this.conn == null) {
+                    connectionManager.closeIdleConnections(60000);
                     this.conn = connectionManager.getConnectionWithTimeout(
                         hostConfiguration,
                         this.params.getConnectionManagerTimeout() 

--- a/commons-httpclient/src/main/java/org/apache/commons/httpclient/HttpMethodDirector.java
+++ b/commons-httpclient/src/main/java/org/apache/commons/httpclient/HttpMethodDirector.java
@@ -152,7 +152,7 @@ class HttpMethodDirector {
         
                 // get a connection, if we need one
                 if (this.conn == null) {
-                    if (connectionManager.getParams().getSoTimeout()>0) {
+                    if (connectionManager.getParams().getSoTimeout() > 0) {
                         connectionManager.closeIdleConnections(connectionManager.getParams().getSoTimeout());
                     } else {
                         connectionManager.closeIdleConnections(DEFAULT_IDLE_TIMEOUT);


### PR DESCRIPTION
Need to close old idle connections before get connection from connection pool.

Because old idle connection can cause connection reset or connection abort, although it is still available.

## Purpose
> To prevent connection reset and connection abort.

## Goals
> Close old idle connections before get connection

TID: [-1234] [] [2018-01-26 13:22:21,837]  INFO {org.apache.axis2.transport.http.HTTPSender} -  Unable to sendViaPost to url[https://xxxxxxxxxx] {org.apache.axis2.transport.http.HTTPSender}
java.net.SocketException: Connection reset
        at java.net.SocketInputStream.read(SocketInputStream.java:210)
        at java.net.SocketInputStream.read(SocketInputStream.java:141)
        at sun.security.ssl.InputRecord.readFully(InputRecord.java:465)
        at sun.security.ssl.InputRecord.read(InputRecord.java:503)
        at sun.security.ssl.SSLSocketImpl.readRecord(SSLSocketImpl.java:973)
        at sun.security.ssl.SSLSocketImpl.readDataRecord(SSLSocketImpl.java:930)
        at sun.security.ssl.AppInputStream.read(AppInputStream.java:105)
        at java.io.BufferedInputStream.fill(BufferedInputStream.java:246)
        at java.io.BufferedInputStream.read(BufferedInputStream.java:265)
        at org.apache.commons.httpclient.HttpParser.readRawLine(HttpParser.java:78)
        at org.apache.commons.httpclient.HttpParser.readLine(HttpParser.java:106)
        at org.apache.commons.httpclient.HttpConnection.readLine(HttpConnection.java:1120)
        at org.apache.commons.httpclient.MultiThreadedHttpConnectionManager$HttpConnectionAdapter.readLine(MultiThreadedHttpConnectionManager.java:1417)
        at org.apache.commons.httpclient.HttpMethodBase.readStatusLine(HttpMethodBase.java:1973)
        at org.apache.commons.httpclient.HttpMethodBase.readResponse(HttpMethodBase.java:1735)
        at org.apache.commons.httpclient.HttpMethodBase.execute(HttpMethodBase.java:1098)
        at org.apache.commons.httpclient.HttpMethodDirector.executeWithRetry(HttpMethodDirector.java:400)
        at org.apache.commons.httpclient.HttpMethodDirector.executeMethod(HttpMethodDirector.java:172)
        at org.apache.commons.httpclient.HttpClient.executeMethod(HttpClient.java:397)
        ....