### PR TITLE
[RE-OPEN] Close idle connection

### DIFF
--- a/commons-httpclient/src/main/java/org/apache/commons/httpclient/HttpMethodDirector.java
+++ b/commons-httpclient/src/main/java/org/apache/commons/httpclient/HttpMethodDirector.java
@@ -71,6 +71,8 @@ class HttpMethodDirector {
     /** The proxy authenticate challange header. */
     public static final String PROXY_AUTH_CHALLENGE = "Proxy-Authenticate";
 
+    private static final int DEFAULT_IDLE_TIMEOUT = 120000;
+
     /** The proxy authenticate response header. */
     public static final String PROXY_AUTH_RESP = "Proxy-Authorization";
 
@@ -150,9 +152,14 @@ class HttpMethodDirector {
         
                 // get a connection, if we need one
                 if (this.conn == null) {
+                    if (connectionManager.getParams().getSoTimeout() > 0) {
+                        connectionManager.closeIdleConnections(connectionManager.getParams().getSoTimeout());
+                    } else {
+                        connectionManager.closeIdleConnections(DEFAULT_IDLE_TIMEOUT);
+                    }
                     this.conn = connectionManager.getConnectionWithTimeout(
                         hostConfiguration,
-                        this.params.getConnectionManagerTimeout() 
+                        this.connectionManager.getParams().getConnectionTimeout()
                     );
                     this.conn.setLocked(true);
                     if (this.params.isAuthenticationPreemptive()

--- a/commons-httpclient/src/test/java/org/apache/commons/httpclient/TestHttpConnectionManager.java
+++ b/commons-httpclient/src/test/java/org/apache/commons/httpclient/TestHttpConnectionManager.java
@@ -257,6 +257,7 @@ public class TestHttpConnectionManager extends HttpClientTestBase {
         this.server.setHttpService(new EchoService());
 
         MultiThreadedHttpConnectionManager connectionManager = new MultiThreadedHttpConnectionManager();
+        connectionManager.getParams().setConnectionTimeout(1);
         connectionManager.getParams().setDefaultMaxConnectionsPerHost(1);
 
         client.setHttpConnectionManager(connectionManager);
@@ -308,6 +309,7 @@ public class TestHttpConnectionManager extends HttpClientTestBase {
         this.server.setHttpService(new EchoService());
 
         MultiThreadedHttpConnectionManager connectionManager = new MultiThreadedHttpConnectionManager();
+        connectionManager.getParams().setConnectionTimeout(1);
         connectionManager.getParams().setDefaultMaxConnectionsPerHost(1);
 
         client.setHttpConnectionManager(connectionManager);
@@ -605,6 +607,7 @@ public class TestHttpConnectionManager extends HttpClientTestBase {
         this.server.setHttpService(new EchoService());
 
         MultiThreadedHttpConnectionManager connectionManager = new MultiThreadedHttpConnectionManager();
+        connectionManager.getParams().setConnectionTimeout(1);
         connectionManager.getParams().setDefaultMaxConnectionsPerHost(1);
 
         client.setHttpConnectionManager(connectionManager);
@@ -713,6 +716,7 @@ public class TestHttpConnectionManager extends HttpClientTestBase {
         this.server.setHttpService(new EchoService());
 
         MultiThreadedHttpConnectionManager connectionManager = new MultiThreadedHttpConnectionManager();
+        connectionManager.getParams().setConnectionTimeout(30000);
         connectionManager.getParams().setIntParameter(
             HttpConnectionManagerParams.MAX_TOTAL_CONNECTIONS, 1);
 


### PR DESCRIPTION
I'm sorry I did not check the test case.
I checked TestCase and modified to set correct connection timeout.

RE-OPEN https://github.com/wso2/wso2-commons-httpclient/pull/18 close old idle connections.

<br />
<br />
<br />

Need to close old idle connections before get connection from connection pool.

Because old idle connection can cause connection reset or connection abort, although it is still available.

## Purpose
> To prevent connection reset and connection abort.

## Goals
> Close old idle connections before get connection

TID: [-1234] [] [2018-01-26 13:22:21,837]  INFO {org.apache.axis2.transport.http.HTTPSender} -  Unable to sendViaPost to url[https://xxxxxxxxxx] {org.apache.axis2.transport.http.HTTPSender}
java.net.SocketException: Connection reset
        at java.net.SocketInputStream.read(SocketInputStream.java:210)
        at java.net.SocketInputStream.read(SocketInputStream.java:141)
        at sun.security.ssl.InputRecord.readFully(InputRecord.java:465)
        at sun.security.ssl.InputRecord.read(InputRecord.java:503)
        at sun.security.ssl.SSLSocketImpl.readRecord(SSLSocketImpl.java:973)
        at sun.security.ssl.SSLSocketImpl.readDataRecord(SSLSocketImpl.java:930)
        at sun.security.ssl.AppInputStream.read(AppInputStream.java:105)
        at java.io.BufferedInputStream.fill(BufferedInputStream.java:246)
        at java.io.BufferedInputStream.read(BufferedInputStream.java:265)
        at org.apache.commons.httpclient.HttpParser.readRawLine(HttpParser.java:78)
        at org.apache.commons.httpclient.HttpParser.readLine(HttpParser.java:106)
        at org.apache.commons.httpclient.HttpConnection.readLine(HttpConnection.java:1120)
        at org.apache.commons.httpclient.MultiThreadedHttpConnectionManager$HttpConnectionAdapter.readLine(MultiThreadedHttpConnectionManager.java:1417)
        at org.apache.commons.httpclient.HttpMethodBase.readStatusLine(HttpMethodBase.java:1973)
        at org.apache.commons.httpclient.HttpMethodBase.readResponse(HttpMethodBase.java:1735)
        at org.apache.commons.httpclient.HttpMethodBase.execute(HttpMethodBase.java:1098)
        at org.apache.commons.httpclient.HttpMethodDirector.executeWithRetry(HttpMethodDirector.java:400)
        at org.apache.commons.httpclient.HttpMethodDirector.executeMethod(HttpMethodDirector.java:172)
        at org.apache.commons.httpclient.HttpClient.executeMethod(HttpClient.java:397)
        ....