### PR TITLE
Add logic to append charset to multi part data, based on a config value

### DIFF
--- a/commons-httpclient/src/main/java/org/apache/commons/httpclient/methods/multipart/FilePart.java
+++ b/commons-httpclient/src/main/java/org/apache/commons/httpclient/methods/multipart/FilePart.java
@@ -102,6 +102,23 @@ public class FilePart extends PartBase {
         }
         this.source = partSource;
     }
+
+    /**
+     * FilePart Constructor.
+     *
+     * @param name the name for this part
+     * @param partSource the source for this part
+     * @param contentType the content type for this part, if <code>null</code> the
+     * {@link #DEFAULT_CONTENT_TYPE default} is used
+     * @param disableSendingMultipartPartCharset whether to send the charset in the Content-Type header
+     * @param charset the charset encoding for this part, if <code>null</code> the
+     * {@link #DEFAULT_CHARSET default} is used
+     */
+    public FilePart(String name, PartSource partSource, String contentType,
+                    boolean disableSendingMultipartPartCharset, String charset) {
+        this(name, partSource, contentType, charset);
+        super.disableSendingMultipartPartCharset = disableSendingMultipartPartCharset;
+    }
         
     /**
      * FilePart Constructor.

--- a/commons-httpclient/src/main/java/org/apache/commons/httpclient/methods/multipart/Part.java
+++ b/commons-httpclient/src/main/java/org/apache/commons/httpclient/methods/multipart/Part.java
@@ -106,6 +106,9 @@ public abstract class Part {
     protected static final byte[] CONTENT_TYPE_BYTES = 
       EncodingUtil.getAsciiBytes(CONTENT_TYPE);
 
+    /** Flag indicating whether to send the charset in the Content-Type header */
+    protected boolean disableSendingMultipartPartCharset = false;
+
     /** Content charset */
     protected static final String CHARSET = "; charset=";
 
@@ -234,7 +237,7 @@ public abstract class Part {
             out.write(CONTENT_TYPE_BYTES);
             out.write(EncodingUtil.getAsciiBytes(contentType));
             String charSet = getCharSet();
-            if (charSet != null) {
+            if (charSet != null && !disableSendingMultipartPartCharset) {
                 out.write(CHARSET_BYTES);
                 out.write(EncodingUtil.getAsciiBytes(charSet));
             }

--- a/commons-httpclient/src/main/java/org/apache/commons/httpclient/methods/multipart/StringPart.java
+++ b/commons-httpclient/src/main/java/org/apache/commons/httpclient/methods/multipart/StringPart.java
@@ -98,6 +98,21 @@ public class StringPart extends PartBase {
      *
      * @param name The name of the part
      * @param value the string to post
+     * @param disableSendingMultipartPartCharset whether to send the charset value in the Content-Type header
+     * @param charset the charset to be used to encode the string, if <code>null</code>
+     * the {@link #DEFAULT_CHARSET default} is used
+     */
+    public StringPart(String name, String value, boolean disableSendingMultipartPartCharset, String charset) {
+        this(name, value, charset);
+        super.disableSendingMultipartPartCharset = disableSendingMultipartPartCharset;
+    }
+
+
+    /**
+     * Constructor.
+     *
+     * @param name The name of the part
+     * @param value the string to post
      */
     public StringPart(String name, String value) {
         this(name, value, null);


### PR DESCRIPTION
### Description
This PR considered a configuration value to avoid changing the content-type header of multi part requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new constructor options for FilePart and StringPart in multipart form submissions, enabling control over charset parameters in Content-Type headers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->