### PR TITLE
Add logic to set content transfer encoding based on a config value

### DIFF
--- a/commons-httpclient/src/main/java/org/apache/commons/httpclient/methods/multipart/FilePart.java
+++ b/commons-httpclient/src/main/java/org/apache/commons/httpclient/methods/multipart/FilePart.java
@@ -119,7 +119,26 @@ public class FilePart extends PartBase {
         this(name, partSource, contentType, charset);
         super.disableSendingMultipartPartCharset = disableSendingMultipartPartCharset;
     }
-        
+
+    /**
+     * FilePart Constructor.
+     *
+     * @param name                                         the name for this part
+     * @param partSource                                   the source for this part
+     * @param contentType                                  the content type for this part, if <code>null</code> the
+     *                                                     {@link #DEFAULT_CONTENT_TYPE default} is used
+     * @param disableSendingMultipartPartCharset           whether to send the charset in the Content-Type header
+     * @param preserveMultipartPartContentTransferEncoding whether to preserve the Content-Transfer-Encoding header
+     * @param charset                                      the charset encoding for this part, if <code>null</code> the
+     *                                                     {@link #DEFAULT_CHARSET default} is used
+     */
+    public FilePart(String name, PartSource partSource, String contentType, boolean disableSendingMultipartPartCharset,
+                    boolean preserveMultipartPartContentTransferEncoding, String charset) {
+        this(name, partSource, contentType, charset);
+        super.disableSendingMultipartPartCharset = disableSendingMultipartPartCharset;
+        super.preserveMultipartPartContentTransferEncoding = preserveMultipartPartContentTransferEncoding;
+    }
+
     /**
      * FilePart Constructor.
      *

--- a/commons-httpclient/src/main/java/org/apache/commons/httpclient/methods/multipart/Part.java
+++ b/commons-httpclient/src/main/java/org/apache/commons/httpclient/methods/multipart/Part.java
@@ -109,6 +109,9 @@ public abstract class Part {
     /** Flag indicating whether to send the charset in the Content-Type header */
     protected boolean disableSendingMultipartPartCharset = false;
 
+    /** Flag indicating whether to preserve the Content-Transfer-Encoding header */
+    protected boolean preserveMultipartPartContentTransferEncoding = false;
+
     /** Content charset */
     protected static final String CHARSET = "; charset=";
 
@@ -254,7 +257,7 @@ public abstract class Part {
      protected void sendTransferEncodingHeader(OutputStream out) throws IOException {
         LOG.trace("enter sendTransferEncodingHeader(OutputStream out)");
         String transferEncoding = getTransferEncoding();
-        if (transferEncoding != null) {
+        if (transferEncoding != null && !preserveMultipartPartContentTransferEncoding) {
             out.write(CRLF_BYTES);
             out.write(CONTENT_TRANSFER_ENCODING_BYTES);
             out.write(EncodingUtil.getAsciiBytes(transferEncoding));

--- a/commons-httpclient/src/main/java/org/apache/commons/httpclient/methods/multipart/StringPart.java
+++ b/commons-httpclient/src/main/java/org/apache/commons/httpclient/methods/multipart/StringPart.java
@@ -107,6 +107,23 @@ public class StringPart extends PartBase {
         super.disableSendingMultipartPartCharset = disableSendingMultipartPartCharset;
     }
 
+    /**
+     * Constructor.
+     *
+     * @param name                                         The name of the part
+     * @param value                                        the string to post
+     * @param disableSendingMultipartPartCharset           whether to send the charset value in the Content-Type header
+     * @param preserveMultipartPartContentTransferEncoding whether to preserve the Content-Transfer-Encoding header
+     * @param charset                                      the charset to be used to encode the string,
+     *                                                     if <code>null</code> the {@link #DEFAULT_CHARSET default}
+     *                                                     is used
+     */
+    public StringPart(String name, String value, boolean disableSendingMultipartPartCharset,
+                      boolean preserveMultipartPartContentTransferEncoding, String charset) {
+        this(name, value, charset);
+        super.disableSendingMultipartPartCharset = disableSendingMultipartPartCharset;
+        super.preserveMultipartPartContentTransferEncoding = preserveMultipartPartContentTransferEncoding;
+    }
 
     /**
      * Constructor.


### PR DESCRIPTION
## Purpose
This pull request introduces the ability to control whether the `Content-Transfer-Encoding` header is sent in the parts of multipart HTTP requests for both file and string parts. It does this by adding a new flag and constructor parameters to the relevant classes.

Related to - https://github.com/wso2/api-manager/issues/4730

## Approach

**Multipart header customization:**

* Added a new `preserveContentTransferEncoding` flag to the `Part` base class, allowing subclasses to control whether the `Content-Transfer-Encoding` header is included.
* Updated the `sendTransferEncodingHeader` method in `Part` to check the new flag before writing the header.
* Added new constructors to `FilePart` and `StringPart` that accept the `preserveContentTransferEncoding` flag, enabling callers to specify this behavior per part.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended multipart form handling with new constructor options to control charset emission and whether Content-Transfer-Encoding headers are sent, enabling finer-grained control over multipart request formatting and compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->