### PR TITLE
Add logic to set content transfer encoding based on a config value

### DIFF
--- a/commons-httpclient/src/main/java/org/apache/commons/httpclient/methods/multipart/Part.java
+++ b/commons-httpclient/src/main/java/org/apache/commons/httpclient/methods/multipart/Part.java
@@ -232,7 +232,7 @@ public abstract class Part {
      * @param out The output stream
      * @throws IOException If an IO problem occurs.
      */
-     protected void sendContentTypeHeader(OutputStream out) throws IOException {
+    protected void sendContentTypeHeader(OutputStream out) throws IOException {
         LOG.trace("enter sendContentTypeHeader(OutputStream out)");
         String contentType = getContentType();
         if (contentType != null) {
@@ -254,10 +254,10 @@ public abstract class Part {
      * @param out The output stream
      * @throws IOException If an IO problem occurs.
      */
-     protected void sendTransferEncodingHeader(OutputStream out) throws IOException {
+    protected void sendTransferEncodingHeader(OutputStream out) throws IOException {
         LOG.trace("enter sendTransferEncodingHeader(OutputStream out)");
         String transferEncoding = getTransferEncoding();
-        if (transferEncoding != null && !preserveMultipartPartContentTransferEncoding) {
+        if (transferEncoding != null) {
             out.write(CRLF_BYTES);
             out.write(CONTENT_TRANSFER_ENCODING_BYTES);
             out.write(EncodingUtil.getAsciiBytes(transferEncoding));


### PR DESCRIPTION
## Purpose
This pull request introduces the ability to control whether the `Content-Transfer-Encoding` header is sent in the parts of multipart HTTP requests for both file and string parts. It does this by adding a new flag and constructor parameters to the relevant classes.

Related to - https://github.com/wso2/api-manager/issues/4730

## Approach

**Multipart header customization:**

* Added a new `preserveContentTransferEncoding` flag to the `Part` base class, allowing subclasses to control whether the `Content-Transfer-Encoding` header is included.
* Added new constructors to `FilePart` and `StringPart` that accept the `preserveContentTransferEncoding` flag, enabling callers to specify this behavior per part.
* If the `preserveContentTransferEncoding` is `false`, allow overwriting the `Content-Transfer-Encoding` header, even if the `Content-Transfer-Encoding` header is sent in the request.
* If the `preserveContentTransferEncoding` is `true`, do not manipulate the `Content-Transfer-Encoding` header in the `Part` base class.
     - If the `Content-Transfer-Encoding` header is not sent in the request - Set the `transferEncoding` to `null` when building the part so that the `sendTransferEncodingHeader` won't set it.
     - If the `Content-Transfer-Encoding` header is sent in the request - Set the `transferEncoding` to the value sent in the request when building the part so that the `sendTransferEncodingHeader` set it and preserve the header value sent in the request.