### PR TITLE
Add support to set ConnectionIdleTimeout

### DIFF
--- a/commons-httpclient/src/main/java/org/apache/commons/httpclient/HttpMethodDirector.java
+++ b/commons-httpclient/src/main/java/org/apache/commons/httpclient/HttpMethodDirector.java
@@ -152,7 +152,9 @@ class HttpMethodDirector {
         
                 // get a connection, if we need one
                 if (this.conn == null) {
-                    if (connectionManager.getParams().getSoTimeout() > 0) {
+                    if (connectionManager.getParams().getConnectionIdleTimeout() > 0) {
+                        connectionManager.closeIdleConnections(connectionManager.getParams().getConnectionIdleTimeout());
+                    } else if (connectionManager.getParams().getSoTimeout() > 0) {
                         connectionManager.closeIdleConnections(connectionManager.getParams().getSoTimeout());
                     } else {
                         connectionManager.closeIdleConnections(DEFAULT_IDLE_TIMEOUT);

--- a/commons-httpclient/src/main/java/org/apache/commons/httpclient/params/HttpConnectionParams.java
+++ b/commons-httpclient/src/main/java/org/apache/commons/httpclient/params/HttpConnectionParams.java
@@ -55,7 +55,12 @@ public class HttpConnectionParams extends DefaultHttpParams {
      * </p>
      * @see java.net.SocketOptions#SO_TIMEOUT
      */
-    public static final String SO_TIMEOUT = "http.socket.timeout"; 
+    public static final String SO_TIMEOUT = "http.socket.timeout";
+
+    /**
+     * Defines the connection idle timeout
+     */
+    public static final String CONNECTION_IDLE_TIMEOUT = "http.connection.idle-timeout";
 
     /**
      * Determines whether Nagle's algorithm is to be used. The Nagle's algorithm 
@@ -160,6 +165,14 @@ public class HttpConnectionParams extends DefaultHttpParams {
      */
     public void setSoTimeout(int timeout) {
         setIntParameter(SO_TIMEOUT, timeout);
+    }
+
+    public int getConnectionIdleTimeout() {
+        return getIntParameter(CONNECTION_IDLE_TIMEOUT, 0);
+    }
+
+    public void setConnectionIdleTimeout(int timeout) {
+        setIntParameter(CONNECTION_IDLE_TIMEOUT, timeout);
     }
 
     /**


### PR DESCRIPTION
This pull request introduces support for a configurable connection idle timeout in the HTTP client, allowing more precise control over when idle connections are closed. The main changes include the addition of a new parameter for idle timeout and updates to the connection management logic to use this parameter.

**Connection Idle Timeout Feature:**

* Added a new constant `CONNECTION_IDLE_TIMEOUT` to `HttpConnectionParams` to define the connection idle timeout parameter.
* Implemented getter and setter methods (`getConnectionIdleTimeout` and `setConnectionIdleTimeout`) in `HttpConnectionParams` for managing the idle timeout value.

**Connection Management Logic:**

* Updated `HttpMethodDirector.executeMethod` to prioritize the new connection idle timeout parameter when closing idle connections, falling back to the socket timeout or a default value if not set.

fix - https://github.com/wso2/product-integrator-mi/issues/4933